### PR TITLE
handle old response of getDeskSidebarItems

### DIFF
--- a/lib/services/api/dio_api.dart
+++ b/lib/services/api/dio_api.dart
@@ -70,7 +70,16 @@ class DioApi implements Api {
           await OfflineStorage.putItem('deskSidebarItems', response.data);
         }
 
-        return DeskSidebarItemsResponse.fromJson(response.data);
+        try {
+          return DeskSidebarItemsResponse.fromJson(response.data);
+        } catch (e) {
+          response.data["message"] = [
+            ...response.data["message"]["Modules"],
+            ...response.data["message"]["Administration"],
+            ...response.data["message"]["Domains"],
+          ];
+          return DeskSidebarItemsResponse.fromJson(response.data);
+        }
       } else if (response.statusCode == HttpStatus.forbidden) {
         throw response;
       } else {

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -162,7 +162,7 @@ class Home extends StatelessWidget {
       ),
       onTap: () {
         model.navigateToView(
-          doctype: item.linkTo,
+          doctype: item.linkTo ?? item.name,
           context: context,
         );
       },


### PR DESCRIPTION
response of getDesksidebarItems has changed in latest develop branch of Frappe Framework, users who were not able to switch to latest version were facing Login issues. 
This temporarily fixes this issue.