### PR TITLE
fix: login breaks when user has set a language that is not English

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -590,7 +590,7 @@ initAwesomeItems() async {
   var moduleDoctypesMapping = {};
 
   for (var item in deskSidebarItems.message) {
-    var desktopPage = await locator<Api>().getDesktopPage(item.label);
+    var desktopPage = await locator<Api>().getDesktopPage(item.name);
 
     desktopPage.message.cards.items.forEach(
       (item) {

--- a/lib/views/home/home_viewmodel.dart
+++ b/lib/views/home/home_viewmodel.dart
@@ -90,7 +90,7 @@ class HomeViewModel extends BaseViewModel {
     try {
       await getDeskSidebarItems();
 
-      currentModule = modules[0].label;
+      currentModule = modules[0].name;
 
       await getDesktopPage(
         currentModule,


### PR DESCRIPTION
When a user that has set a language that is not English the login breaks. This happens because when using a different language the label becomes the translated text, and when looking for the desktop page the server returns `404 Not Found`. This PR fixes this by using the `name` instead `label` which never changes regardless of the language selected.