### PR TITLE
fix: error handling

### DIFF
--- a/lib/views/login/login_view.dart
+++ b/lib/views/login/login_view.dart
@@ -133,23 +133,28 @@ class Login extends StatelessWidget {
                                         page: HomeView(),
                                       );
                                     }
-                                  } catch (e) {
-                                    var _e = e as ErrorResponse;
-
-                                    if (_e.statusCode ==
+                                  } on ErrorResponse catch (e) {
+                                    if (e.statusCode ==
                                         HttpStatus.unauthorized) {
                                       FrappeAlert.errorAlert(
                                         title: "Not Authorized",
-                                        subtitle: _e.statusMessage,
+                                        subtitle: e.statusMessage,
                                         context: context,
                                       );
                                     } else {
                                       FrappeAlert.errorAlert(
                                         title: "Error",
-                                        subtitle: _e.statusMessage,
+                                        subtitle: e.statusMessage,
                                         context: context,
                                       );
                                     }
+                                  } catch (e) {
+                                    print("$e");
+                                    FrappeAlert.errorAlert(
+                                      title: "Error",
+                                      subtitle: "Internal error occured!",
+                                      context: context,
+                                    );
                                   }
                                 }
                               }


### PR DESCRIPTION
Since Flutter, by default, does not allow [Insecure HTTP connections](https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android), when an insecure `server URL` passed on a `Login Page`, It just does not provide any response (not even the error). The reason is that there is `HandshakeException` thrown which is eventually never handled. I have done the handling part with some minor refactoring.

Also, for `Login` page, handled unhandled exceptions

## Changes Made:
 - Handle the `HandshakeException` in `DioApi.login` -  which might be thrown when any insecure (HTTP) request is made.
 - Handle Unhandled exceptions.
 - Refactor `DioApi.login` method

## Before: 
 -  Login page with no response

## After:
Insecure Request Exception
![image](https://user-images.githubusercontent.com/43115036/127653359-9156f7b0-bf66-4d85-b082-151032145593.png)

Unhandled Exception
![image](https://user-images.githubusercontent.com/43115036/127653071-36945fc1-2256-4cc9-8a38-fdec56f40787.png)

