### PR TITLE
fix: add defaultValue to `userId` getter

### DIFF
--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -10,38 +10,23 @@ class Config {
         defaultValue: false,
       );
 
-  String? get userId => Uri.decodeFull(
-        configContainer.get(
-          'userId',
-        ),
-      );
+  String? get userId =>
+      Uri.decodeFull(configContainer.get('userId', defaultValue: ""));
 
-  String get user => configContainer.get(
-        'user',
-      );
+  String get user => configContainer.get('user');
 
   String? get primaryCacheKey {
-    if (baseUrl != null && userId != null) {
-      return "$baseUrl$userId";
-    } else {
-      return null;
-    }
+    if (baseUrl == null || userId == null) return null;
+    return "$baseUrl$userId";
   }
 
-  String get version => configContainer.get(
-        'version',
-      );
+  String get version => configContainer.get('version');
 
-  String? get baseUrl => configContainer.get(
-        'baseUrl',
-      );
+  String? get baseUrl => configContainer.get('baseUrl');
 
   Uri? get uri {
-    if (baseUrl != null) {
-      return Uri.parse(baseUrl!);
-    } else {
-      return null;
-    }
+    if (baseUrl == null) return null;
+    return Uri.parse(baseUrl!);
   }
 
   static Future set(String k, dynamic v) async {


### PR DESCRIPTION
## Issue
When there is false login occurs and then I do a hot restart (in development env) it gives me a red error saying `the getter 'length' was called on null`.  After that no matter how many reinstalls I do, it does not resolve until I clear the app data. 

![image](https://user-images.githubusercontent.com/43115036/127656100-615f6e9c-eec4-4e5b-bad9-24883f997972.png)


## Reason
Regardless of the status of the login (success or failure), `userId` **key** is updating in the local storage with either actual userId (in the case of success) or `null` (in the case of failure). So, when `userId` **getter** tries to get the data for the `userId` **key**, it actually returns the value which is `null` (in the case of failure of course), and as `Uri.decodeFull` does not accept `null`, it throws an error.

(Because the actual key `userId` is set at the local storage as `null`, dart linter does give the error being `null`)

**Suggestion**: There should be a check before adding/updating values in the local storage.

## Changes Made
 - add `defaultValue` in the `userId` getter
 - refactor `config.dart`
